### PR TITLE
Require rack-attack v5.3.1

### DIFF
--- a/ahoy_matey.gemspec
+++ b/ahoy_matey.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "request_store"
   spec.add_dependency "uuidtools"
   spec.add_dependency "safely_block", ">= 0.1.1"
-  spec.add_dependency "rack-attack"
+  spec.add_dependency "rack-attack", "5.3.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Fixes this issue on Pro:

```
/Users/bcastle/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/bundler/gems/ahoy-137b05442829/lib/ahoy/throttle.rb:5:in `<class:Throttle>': #<Class:Rack::Attack>#throttle at /Users/bcastle/.rbenv/versions/2.4.2/lib/ruby/2.4.0/forwardable.rb:157 forwarding to private method NilClass#throttle
/Users/bcastle/.rbenv/versions/2.4.2/lib/ruby/2.4.0/forwardable.rb:227:in `throttle': undefined method `throttle' for nil:NilClass (NoMethodError)
```